### PR TITLE
feat(case-next): vessel calibre measurement (third mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Chrome debugging is pre-configured in `.vscode/launch.json` for `http://localhos
 ### Project Structure
 
 - `/index.html` - Marketing/landing page (standalone, uses Tailwind CSS via CDN)
-- `/case/` - The 3D viewer application
+- `/case/` - The 3D viewer application (legacy, Sketchfab iframe)
   - `index.html` - Viewer HTML template with Sketchfab iframe
   - `main.js` - Sketchfab API initialization, node tree management
   - `measure.js` - 3D click-to-measure tool with SVG overlay
@@ -40,6 +40,18 @@ Chrome debugging is pre-configured in `.vscode/launch.json` for `http://localhos
   - `mudaCor.js` - Light/dark theme switching
   - `laudo.js` / `mainLinhaLaudo.js` - Report/documentation features
   - `botao_video.js` - YouTube video modal integration
+- `/case-next/` - The active 3D viewer (Three.js, replaces Sketchfab iframe)
+  - `index.html` - Viewer shell HTML; loads `main.js` as an ES module
+  - `main.js` - Composition root: parses URL, loads GLB, mounts scene, wires UI
+  - `world.js` - Three.js wrapper: scene/camera/raycaster, mesh registry, measurement primitives (lines, pills, endpoints, centerlines, diameter circles), outline pass, lupa renderer
+  - `loader.js` - Fetches GLBs from R2 by UID
+  - `dom.js` - DOM helpers: structures panel, FAB, measurement menu, vessel-type modal, toolbars, bottom sheet, modals
+  - `measurement.js` - Linear measurement state machine (2-point distance)
+  - `volume.js` - Volume measurement state machine (signed tetrahedra over mesh)
+  - `calibre.js` - Vessel-diameter measurement state machine (calibre mode)
+  - `calibre-geom.js` - Pure-math module for calibre: triangle-plane intersection, PCA Jacobi, polygon area/centroid, centerline marching, screen-space line picking (no DOM, no globals)
+  - `ar.js` - AR button + QR modal + USDZ generation for iOS Quick Look
+  - `style.css` - All viewer styles
 - `/upload/` - Clinician self-service upload page (talks to the `mesh-processor` backend)
   - `index.html` - Multi-file STL input, 4-state UI (idle / processing / done / error) with Tailwind CDN
   - `upload.js` - Posts files to `POST /upload`, then polls `GET /status/{uid}` until ready
@@ -55,7 +67,14 @@ Chrome debugging is pre-configured in `.vscode/launch.json` for `http://localhos
 
 **Theme System**: `mudaCor.js` handles dark/light mode by modifying multiple DOM elements and recalculating text luminance for readability.
 
-**Measurement Tool**: Uses `getWorldToScreenCoordinates` from Sketchfab API to project 3D points to 2D, then draws SVG lines. Measurements auto-clear on camera movement.
+**Measurement Tool** (legacy `/case/`): Uses `getWorldToScreenCoordinates` from Sketchfab API to project 3D points to 2D, then draws SVG lines. Measurements auto-clear on camera movement.
+
+**Measurement Tools** (`/case-next/`): three modes share a FAB pill + dropdown:
+- **Linear** (`measurement.js`): 2-point Euclidean distance in mm, drawn as a Line2 with a label pill at the midpoint.
+- **Volume** (`volume.js`): tap a mesh; computes real volume in cm³ via signed-tetrahedron sum over its triangles. Detects non-manifold meshes (open edges) and shows a `~` warn pill.
+- **Calibre** (`calibre.js` + `calibre-geom.js`): tap one or two points on a vessel surface. Algorithm: cast ray inward from P1 to find the opposite lumen wall → midpoint = local center C0. PCA over nearby vertices gives the centerline tangent. Iterative marching cuts cross-section polygons perpendicular to the tangent and recenters on each polygon's centroid, until the mesh boundary is reached, a bifurcation is detected (area > 4× previous), or P2 is reached. The centerline is rendered as a glowing inner Line2 (`depthTest:false`). Clicking on the centerline drops a circle perpendicular to the local tangent with diameter = `2·√(area/π)` (equivalent-circle diameter — clinical standard). Drag-along-centerline re-runs `diameterAt` on every pointermove. Multi-vessel meshes (multiple lumens in one GLB node) are handled by picking the polygon whose centroid is closest to the last centerline point.
+
+**Future work — vessel centerline service**: the current calibre centerline extraction is a local marching algorithm in JS. It works well for straight/curved single vessels but can fail on branched topology. A more robust approach would be a Python service (similar to `mesh-processor` on Railway) running VTK or skimage skeletonization to precompute centerlines per mesh during upload. The viewer would then download the centerline polylines alongside the GLB and the calibre mode would be reduced to "click on the precomputed centerline → measure", removing the marching algorithm entirely.
 
 **Upload flow (`/upload/`)**: Two-phase to accommodate Sketchfab's async server-side processing:
 1. `POST /upload` with a `FormData` containing each STL under the repeated field name `files` (not `files[]`). Response is immediate and contains `{uid, viewer_url, ...}`.

--- a/case-next/calibre-geom.js
+++ b/case-next/calibre-geom.js
@@ -1,0 +1,501 @@
+// case-next/calibre-geom.js
+// Math puro para o modo Calibre. Não toca DOM, não importa world.
+// Recebe THREE pra construir Vector3 mas não acessa scene/renderer.
+//
+// Conteúdo:
+//  • crossSection(soup, origin, normal)        → polígonos (multi-lumen aware)
+//  • polygonArea(polygon, normal)              → área planar
+//  • polygonCentroid(polygon)                  → centroide
+//  • pcaJacobi(points)                         → autovalores/vetores 3×3
+//  • extractCenterline({…})                    → marcha local P1[→P2]
+//  • diameterAt(soup, C, tangent)              → diâmetro equivalente
+//  • pickNearestSegment(screenPts, x, y, thr)  → screen-space line picking
+
+import * as THREE from "three";
+
+// ===========================================================================
+// Constantes
+// ===========================================================================
+
+const EPSILON = 1e-6;
+const QUANTIZE = 1e4;                  // 1/0.0001 mm pra parear endpoints
+
+// Marcha
+const MARCH_MAX_STEPS = 30;
+const MARCH_STEP_MIN_MM = 1.0;
+const MARCH_STEP_MAX_MM = 3.0;
+const STEP_TO_DIAMETER_RATIO = 0.25;
+const PCA_RADIUS_MULT = 2.0;
+const PCA_MIN_POINTS = 20;
+const TUBULARITY_THRESHOLD = 0.6;      // λ1/λ0 — abaixo é tubular o suficiente
+const SMOOTH_BLEND = 0.6;
+const AREA_GROWTH_LIMIT = 4.0;
+const P2_PROXIMITY_DIAM_MULT = 2.0;
+const P2_UNREACHED_DIAM_MULT = 3.0;
+const MIN_VALID_AREA_MM2 = 0.01;
+
+// Jacobi
+const JACOBI_MAX_SWEEPS = 30;
+const JACOBI_EPSILON = 1e-10;
+
+// ===========================================================================
+// Scratch buffers (evita GC em loops quentes)
+// ===========================================================================
+
+const _e0 = new THREE.Vector3();
+const _e1 = new THREE.Vector3();
+const _e2 = new THREE.Vector3();
+const _tmp = new THREE.Vector3();
+
+// ===========================================================================
+// Triangle-plane intersection
+// ===========================================================================
+
+function quantKey(v) {
+  return (
+    Math.round(v.x * QUANTIZE) + "_" +
+    Math.round(v.y * QUANTIZE) + "_" +
+    Math.round(v.z * QUANTIZE)
+  );
+}
+
+// Recorta triangle soup por plano. Retorna array de polígonos fechados
+// (cada um = array de Vector3, fecho implícito — último != primeiro).
+// soup: { positions: Float32Array em world-space, indices?: Uint32Array }
+export function crossSection(soup, planeOrigin, planeNormal) {
+  const { positions, indices } = soup;
+  const triCount = indices ? indices.length / 3 : positions.length / 9;
+  const segments = [];
+
+  for (let t = 0; t < triCount; t++) {
+    let i0, i1, i2;
+    if (indices) {
+      i0 = indices[t * 3] * 3;
+      i1 = indices[t * 3 + 1] * 3;
+      i2 = indices[t * 3 + 2] * 3;
+    } else {
+      i0 = t * 9;
+      i1 = t * 9 + 3;
+      i2 = t * 9 + 6;
+    }
+
+    _e0.set(positions[i0], positions[i0 + 1], positions[i0 + 2]);
+    _e1.set(positions[i1], positions[i1 + 1], positions[i1 + 2]);
+    _e2.set(positions[i2], positions[i2 + 1], positions[i2 + 2]);
+
+    const d0 = _tmp.copy(_e0).sub(planeOrigin).dot(planeNormal);
+    const d1 = _tmp.copy(_e1).sub(planeOrigin).dot(planeNormal);
+    const d2 = _tmp.copy(_e2).sub(planeOrigin).dot(planeNormal);
+
+    if ((d0 > EPSILON && d1 > EPSILON && d2 > EPSILON) ||
+        (d0 < -EPSILON && d1 < -EPSILON && d2 < -EPSILON)) continue;
+
+    const pts = [];
+    _addEdgeIntersection(_e0, _e1, d0, d1, pts);
+    _addEdgeIntersection(_e1, _e2, d1, d2, pts);
+    _addEdgeIntersection(_e2, _e0, d2, d0, pts);
+
+    if (pts.length === 2) segments.push([pts[0], pts[1]]);
+    // 0 / 1 / 3+ pontos: degenerado (triângulo tangente). Ignora.
+  }
+
+  return _chainSegments(segments);
+}
+
+function _addEdgeIntersection(va, vb, da, db, out) {
+  if (da * db > 0) return;
+  if (Math.abs(da) < EPSILON && Math.abs(db) < EPSILON) return;
+  if (Math.abs(da) < EPSILON) { out.push(va.clone()); return; }
+  if (Math.abs(db) < EPSILON) { out.push(vb.clone()); return; }
+  const t = da / (da - db);
+  out.push(new THREE.Vector3().lerpVectors(va, vb, t));
+}
+
+function _chainSegments(segments) {
+  if (segments.length === 0) return [];
+
+  const hash = new Map();
+  for (let i = 0; i < segments.length; i++) {
+    const ka = quantKey(segments[i][0]);
+    const kb = quantKey(segments[i][1]);
+    if (!hash.has(ka)) hash.set(ka, []);
+    if (!hash.has(kb)) hash.set(kb, []);
+    hash.get(ka).push({ segIdx: i, end: 0 });
+    hash.get(kb).push({ segIdx: i, end: 1 });
+  }
+
+  const visited = new Array(segments.length).fill(false);
+  const polygons = [];
+
+  for (let start = 0; start < segments.length; start++) {
+    if (visited[start]) continue;
+    const poly = [segments[start][0].clone()];
+    let curSegIdx = start;
+    let curEnd = 1;
+
+    let safety = segments.length + 10;
+    while (safety-- > 0) {
+      if (visited[curSegIdx]) break;
+      visited[curSegIdx] = true;
+
+      const next = segments[curSegIdx][curEnd];
+      poly.push(next.clone());
+
+      const key = quantKey(next);
+      const cands = hash.get(key) || [];
+      let found = null;
+      for (const c of cands) {
+        if (!visited[c.segIdx]) { found = c; break; }
+      }
+      if (!found) break;
+      curSegIdx = found.segIdx;
+      curEnd = 1 - found.end;
+
+      if (poly.length > 2 && quantKey(poly[0]) === quantKey(poly[poly.length - 1])) {
+        poly.pop();   // remove duplicado de fecho
+        break;
+      }
+    }
+
+    if (poly.length >= 3) polygons.push(poly);
+  }
+
+  return polygons;
+}
+
+// ===========================================================================
+// Polygon utils
+// ===========================================================================
+
+export function polygonArea(polygon, planeNormal) {
+  if (polygon.length < 3) return 0;
+  const sum = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  for (let i = 0; i < polygon.length; i++) {
+    const a = polygon[i];
+    const b = polygon[(i + 1) % polygon.length];
+    c.crossVectors(a, b);
+    sum.add(c);
+  }
+  return Math.abs(sum.dot(planeNormal)) * 0.5;
+}
+
+export function polygonCentroid(polygon) {
+  const c = new THREE.Vector3();
+  if (polygon.length === 0) return c;
+  for (const p of polygon) c.add(p);
+  c.divideScalar(polygon.length);
+  return c;
+}
+
+// ===========================================================================
+// PCA via Jacobi (3×3 symmetric eigendecomp)
+// ===========================================================================
+
+export function pcaJacobi(points) {
+  if (points.length < 4) return null;
+
+  const centroid = new THREE.Vector3();
+  for (const p of points) centroid.add(p);
+  centroid.divideScalar(points.length);
+
+  let cxx = 0, cyy = 0, czz = 0, cxy = 0, cxz = 0, cyz = 0;
+  for (const p of points) {
+    const dx = p.x - centroid.x;
+    const dy = p.y - centroid.y;
+    const dz = p.z - centroid.z;
+    cxx += dx * dx; cyy += dy * dy; czz += dz * dz;
+    cxy += dx * dy; cxz += dx * dz; cyz += dy * dz;
+  }
+  const n = points.length;
+  cxx /= n; cyy /= n; czz /= n; cxy /= n; cxz /= n; cyz /= n;
+
+  // Diagonais e off-diagonais (matriz simétrica)
+  let a00 = cxx, a11 = cyy, a22 = czz;
+  let a01 = cxy, a02 = cxz, a12 = cyz;
+  // V começa como identidade (colunas serão autovetores)
+  let v00 = 1, v01 = 0, v02 = 0;
+  let v10 = 0, v11 = 1, v12 = 0;
+  let v20 = 0, v21 = 0, v22 = 1;
+
+  for (let sweep = 0; sweep < JACOBI_MAX_SWEEPS; sweep++) {
+    const off = Math.abs(a01) + Math.abs(a02) + Math.abs(a12);
+    if (off < JACOBI_EPSILON) break;
+
+    let pq;
+    if (Math.abs(a01) >= Math.abs(a02) && Math.abs(a01) >= Math.abs(a12)) pq = 0;
+    else if (Math.abs(a02) >= Math.abs(a12)) pq = 1;
+    else pq = 2;
+
+    let app, aqq, apq;
+    if (pq === 0) { app = a00; aqq = a11; apq = a01; }
+    else if (pq === 1) { app = a00; aqq = a22; apq = a02; }
+    else { app = a11; aqq = a22; apq = a12; }
+
+    const theta = (aqq - app) / (2 * apq);
+    let t;
+    if (theta === 0) t = 1;
+    else if (Math.abs(theta) > 1e10) t = 1 / (2 * theta);
+    else t = Math.sign(theta) / (Math.abs(theta) + Math.sqrt(theta * theta + 1));
+    const c = 1 / Math.sqrt(t * t + 1);
+    const s = t * c;
+
+    const new_app = app - t * apq;
+    const new_aqq = aqq + t * apq;
+    if (pq === 0) { a00 = new_app; a11 = new_aqq; a01 = 0;
+                    const ap = a02, aq = a12;
+                    a02 = c * ap - s * aq; a12 = s * ap + c * aq;
+                    const t0 = v00, t1 = v10, t2 = v20;
+                    const u0 = v01, u1 = v11, u2 = v21;
+                    v00 = c * t0 - s * u0; v01 = s * t0 + c * u0;
+                    v10 = c * t1 - s * u1; v11 = s * t1 + c * u1;
+                    v20 = c * t2 - s * u2; v21 = s * t2 + c * u2; }
+    else if (pq === 1) { a00 = new_app; a22 = new_aqq; a02 = 0;
+                         const ap = a01, aq = a12;
+                         a01 = c * ap - s * aq; a12 = s * ap + c * aq;
+                         const t0 = v00, t1 = v10, t2 = v20;
+                         const u0 = v02, u1 = v12, u2 = v22;
+                         v00 = c * t0 - s * u0; v02 = s * t0 + c * u0;
+                         v10 = c * t1 - s * u1; v12 = s * t1 + c * u1;
+                         v20 = c * t2 - s * u2; v22 = s * t2 + c * u2; }
+    else { a11 = new_app; a22 = new_aqq; a12 = 0;
+           const ap = a01, aq = a02;
+           a01 = c * ap - s * aq; a02 = s * ap + c * aq;
+           const t0 = v01, t1 = v11, t2 = v21;
+           const u0 = v02, u1 = v12, u2 = v22;
+           v01 = c * t0 - s * u0; v02 = s * t0 + c * u0;
+           v11 = c * t1 - s * u1; v12 = s * t1 + c * u1;
+           v21 = c * t2 - s * u2; v22 = s * t2 + c * u2; }
+  }
+
+  const eigs = [
+    { val: a00, vec: new THREE.Vector3(v00, v10, v20) },
+    { val: a11, vec: new THREE.Vector3(v01, v11, v21) },
+    { val: a22, vec: new THREE.Vector3(v02, v12, v22) },
+  ];
+  eigs.sort((a, b) => b.val - a.val);
+  return {
+    eigenvalues: [eigs[0].val, eigs[1].val, eigs[2].val],
+    eigenvectors: [eigs[0].vec.normalize(), eigs[1].vec.normalize(), eigs[2].vec.normalize()],
+    centroid,
+  };
+}
+
+// ===========================================================================
+// Centerline marching
+// ===========================================================================
+
+// raycastInternal: função(origin: Vec3, dir: Vec3) → Vec3 | null
+//   Cabe ao caller usar THREE.Raycaster contra um mesh específico, oferecendo
+//   o ponto da "outra parede" do vaso. Se mesh é aberto ou origin já está
+//   fora, deve retornar null.
+//
+// P1_normal e P2_normal: world-space, já transformados pela matrixNormal.
+export function extractCenterline({ soup, P1, P1_normal, P2 = null, P2_normal = null, raycastInternal }) {
+  const inwardDir = P1_normal.clone().multiplyScalar(-1).normalize();
+  const P1_opp = raycastInternal(P1, inwardDir);
+  if (!P1_opp) return null;
+
+  const C0 = new THREE.Vector3().addVectors(P1, P1_opp).multiplyScalar(0.5);
+  const diameter0 = P1.distanceTo(P1_opp);
+
+  let P2_opp = null;
+  let C2 = null;
+  if (P2 && P2_normal) {
+    const inward2 = P2_normal.clone().multiplyScalar(-1).normalize();
+    P2_opp = raycastInternal(P2, inward2);
+    if (P2_opp) C2 = new THREE.Vector3().addVectors(P2, P2_opp).multiplyScalar(0.5);
+  }
+
+  // PCA local pra tangente inicial
+  const radius = PCA_RADIUS_MULT * diameter0;
+  const radiusSq = radius * radius;
+  const pcaPoints = [];
+  const positions = soup.positions;
+  const vertCount = positions.length / 3;
+  for (let i = 0; i < vertCount; i++) {
+    const dx = positions[i * 3] - C0.x;
+    const dy = positions[i * 3 + 1] - C0.y;
+    const dz = positions[i * 3 + 2] - C0.z;
+    if (dx * dx + dy * dy + dz * dz <= radiusSq) {
+      pcaPoints.push(new THREE.Vector3(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]));
+    }
+  }
+  if (pcaPoints.length < PCA_MIN_POINTS) {
+    return {
+      points: [C0.clone()],
+      P1_opp, diameter0,
+      tangent0: P1_normal.clone(),
+      isTubular: false,
+      fallback: "none",
+      warning: "Vizinhança insuficiente para estimar a direção do vaso.",
+    };
+  }
+  const pca = pcaJacobi(pcaPoints);
+  if (!pca) {
+    return {
+      points: [C0.clone()],
+      P1_opp, diameter0,
+      tangent0: P1_normal.clone(),
+      isTubular: false,
+      fallback: "none",
+      warning: "Não foi possível estimar a direção do vaso.",
+    };
+  }
+  const tubularity = pca.eigenvalues[1] / Math.max(pca.eigenvalues[0], EPSILON);
+  const isTubular = tubularity < TUBULARITY_THRESHOLD;
+
+  let tangent = pca.eigenvectors[0].clone().normalize();
+  if (C2 && tangent.dot(_tmp.subVectors(C2, C0)) < 0) {
+    tangent.multiplyScalar(-1);
+  }
+
+  const stepSize = Math.min(MARCH_STEP_MAX_MM, Math.max(MARCH_STEP_MIN_MM, diameter0 * STEP_TO_DIAMETER_RATIO));
+  const tangent0 = tangent.clone();
+
+  // Forward march
+  const forward = [C0.clone()];
+  {
+    let prevArea = null;
+    let cCur = C0.clone();
+    let vCur = tangent.clone();
+    for (let s = 0; s < MARCH_MAX_STEPS; s++) {
+      const guess = new THREE.Vector3().copy(cCur).addScaledVector(vCur, stepSize);
+      const polys = crossSection(soup, guess, vCur);
+      if (polys.length === 0) break;
+
+      let bestPoly = null;
+      let bestDist = Infinity;
+      for (const poly of polys) {
+        const cen = polygonCentroid(poly);
+        const d = cen.distanceTo(cCur);
+        if (d < bestDist) { bestDist = d; bestPoly = poly; }
+      }
+      if (!bestPoly) break;
+
+      const area = polygonArea(bestPoly, vCur);
+      if (area < MIN_VALID_AREA_MM2) break;
+      if (prevArea !== null && area > AREA_GROWTH_LIMIT * prevArea) break;
+
+      const cNew = polygonCentroid(bestPoly);
+      const vNew = new THREE.Vector3().subVectors(cNew, cCur);
+      if (vNew.lengthSq() < EPSILON) break;
+      vNew.normalize();
+      vCur.lerp(vNew, SMOOTH_BLEND).normalize();
+      cCur.copy(cNew);
+      forward.push(cCur.clone());
+      prevArea = area;
+
+      if (C2 && cCur.distanceTo(C2) < P2_PROXIMITY_DIAM_MULT * diameter0) break;
+    }
+  }
+
+  // Backward march (apenas se sem P2)
+  const backward = [];
+  if (!C2) {
+    let prevArea = null;
+    let cCur = C0.clone();
+    let vCur = tangent0.clone().multiplyScalar(-1).normalize();
+    for (let s = 0; s < MARCH_MAX_STEPS; s++) {
+      const guess = new THREE.Vector3().copy(cCur).addScaledVector(vCur, stepSize);
+      const polys = crossSection(soup, guess, vCur);
+      if (polys.length === 0) break;
+
+      let bestPoly = null;
+      let bestDist = Infinity;
+      for (const poly of polys) {
+        const cen = polygonCentroid(poly);
+        const d = cen.distanceTo(cCur);
+        if (d < bestDist) { bestDist = d; bestPoly = poly; }
+      }
+      if (!bestPoly) break;
+
+      const area = polygonArea(bestPoly, vCur);
+      if (area < MIN_VALID_AREA_MM2) break;
+      if (prevArea !== null && area > AREA_GROWTH_LIMIT * prevArea) break;
+
+      const cNew = polygonCentroid(bestPoly);
+      const vNew = new THREE.Vector3().subVectors(cNew, cCur);
+      if (vNew.lengthSq() < EPSILON) break;
+      vNew.normalize();
+      vCur.lerp(vNew, SMOOTH_BLEND).normalize();
+      cCur.copy(cNew);
+      backward.push(cCur.clone());
+      prevArea = area;
+    }
+    backward.reverse();
+  }
+
+  let fallback = "none";
+  const fullPoints = [...backward, ...forward];
+
+  if (C2) {
+    const lastPoint = fullPoints[fullPoints.length - 1];
+    if (lastPoint.distanceTo(C2) > P2_UNREACHED_DIAM_MULT * diameter0) {
+      fallback = "straight";
+    }
+    fullPoints.push(C2.clone());
+  }
+
+  return {
+    points: fullPoints,
+    P1_opp,
+    P2_opp,
+    diameter0,
+    tangent0,
+    isTubular,
+    fallback,
+  };
+}
+
+// ===========================================================================
+// Diâmetro num ponto
+// ===========================================================================
+
+export function diameterAt(soup, C, tangent) {
+  const polys = crossSection(soup, C, tangent);
+  if (polys.length === 0) return null;
+  let bestPoly = null;
+  let bestDist = Infinity;
+  for (const poly of polys) {
+    const cen = polygonCentroid(poly);
+    const d = cen.distanceTo(C);
+    if (d < bestDist) { bestDist = d; bestPoly = poly; }
+  }
+  if (!bestPoly) return null;
+  const area = polygonArea(bestPoly, tangent);
+  if (area < MIN_VALID_AREA_MM2) return null;
+  return {
+    diameter: 2 * Math.sqrt(area / Math.PI),
+    polygon: bestPoly,
+  };
+}
+
+// ===========================================================================
+// Screen-space line picking
+// ===========================================================================
+
+// screenPoints: array de {x, y} já projetados pra pixel coords.
+// Retorna { segmentIndex, t, distance } ou null se nada dentro de `threshold`.
+export function pickNearestSegment(screenPoints, x, y, threshold = 22) {
+  let best = null;
+  let bestDist = threshold;
+  for (let i = 0; i < screenPoints.length - 1; i++) {
+    const a = screenPoints[i];
+    const b = screenPoints[i + 1];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const lenSq = dx * dx + dy * dy;
+    if (lenSq < 1e-6) continue;
+    let t = ((x - a.x) * dx + (y - a.y) * dy) / lenSq;
+    t = Math.max(0, Math.min(1, t));
+    const px = a.x + t * dx;
+    const py = a.y + t * dy;
+    const d = Math.hypot(x - px, y - py);
+    if (d < bestDist) {
+      bestDist = d;
+      best = { segmentIndex: i, t, distance: d };
+    }
+  }
+  return best;
+}

--- a/case-next/calibre.js
+++ b/case-next/calibre.js
@@ -1,0 +1,550 @@
+// case-next/calibre.js
+// Máquina de estado do modo Calibre (diâmetro de vaso).
+// Espelha a forma do measurement.js e volume.js.
+//
+// Fluxo: PLACING_P1 → CANDIDATE_P1 → EXTRACTING_CL
+//        → READY_SHORT (só P1)
+//             ├─ tap centerline → CIRCLE_PLACED
+//             └─ tap mesh      → PLACING_P2 → CANDIDATE_P2 → EXTRACTING_CL_P1P2 → READY_LONG
+//                                                                                  └─ tap centerline → CIRCLE_PLACED
+//        → CIRCLE_PLACED
+//             ├─ drag centerline    → atualiza ao vivo
+//             ├─ confirm            → COMMITTED (pin) → permite + Nova
+//             └─ cancel             → READY_*
+//
+// Multi-medição: após confirm, _committed[] guarda {circle, pill, ...}.
+// + Nova reinicia em PLACING_P1.
+
+import * as geom from "./calibre-geom.js";
+
+const STATE = Object.freeze({
+  IDLE: "idle",
+  PLACING_P1: "placing-p1",
+  CANDIDATE_P1: "candidate-p1",
+  EXTRACTING_CL: "extracting-cl",
+  READY_SHORT: "ready-short",
+  PLACING_P2: "placing-p2",
+  CANDIDATE_P2: "candidate-p2",
+  EXTRACTING_CL_P1P2: "extracting-cl-p1p2",
+  READY_LONG: "ready-long",
+  CIRCLE_PLACED: "circle-placed",
+  COMMITTED: "committed",
+});
+
+const TAP_THRESHOLD_PX = 15;
+const TAP_THRESHOLD_MS = 500;
+const HANDLE_HITBOX_PX = 44;
+const CENTERLINE_PICK_THRESHOLD_PX = 22;
+
+let _world = null;
+let _dom = null;
+let _hint = null;
+let _toolbar = null;
+let _loupe = null;
+let _onExit = null;
+
+let _state = STATE.IDLE;
+
+// Estado transiente (antes de pin)
+let _candidate = null;          // { id, point3D, meshName, faceIndex }
+let _P1 = null;                 // { id (endpoint), point3D, meshName, faceIndex }
+let _P2 = null;
+let _centerlineId = null;
+let _circleId = null;
+let _pillId = null;
+let _circleData = null;         // { center, tangent, diameter }
+let _highlightedMeshName = null;
+
+// Medições já confirmadas (pin) — persistem até exit ou recarga
+const _committed = [];          // { circleId, pillId, meshName, diameter, center, tangent }
+
+let _touch = null;              // pointer tracking
+
+export function init({ world, dom, hint, onExit }) {
+  _world = world;
+  _dom = dom;
+  _hint = hint;
+  _onExit = onExit;
+
+  _toolbar = dom.mountCalibreToolbar({
+    onCancel: _exit,
+    onConfirm: _onConfirm,
+    onNew: _onNew,
+    onExit: _exit,
+  });
+
+  _loupe = dom.mountLoupe();
+  world.attachLoupeCanvas(_loupe.canvas);
+
+  world.onCameraChange(() => {
+    if (_loupe && (_state === STATE.CANDIDATE_P1 || _state === STATE.CANDIDATE_P2) && _candidate) {
+      const screen = _world.projectToScreen(_candidate.point3D);
+      _loupe.setPosition(screen.x, screen.y);
+    }
+  });
+
+  const canvas = document.getElementById("canvas");
+  canvas.addEventListener("pointerdown", _onPointerDown);
+  canvas.addEventListener("pointermove", _onPointerMove);
+  canvas.addEventListener("pointerup",   _onPointerUp);
+  canvas.addEventListener("pointercancel", _onPointerUp);
+
+  _enter(STATE.IDLE);
+
+  return {
+    startCalibre,
+    getState: () => _state,
+    getCommittedCount: () => _committed.length,
+    onMeshVisibilityChange,
+  };
+}
+
+function startCalibre() {
+  _enter(STATE.PLACING_P1);
+}
+
+function _exit() {
+  _clearTransient();
+  _clearCommitted();
+  _state = STATE.IDLE;
+  _hint.clear();
+  _toolbar.hide();
+  if (_onExit) _onExit();
+}
+
+function _clearCommitted() {
+  for (const c of _committed) {
+    if (c.circleId !== null) _world.removeDiameterCircle(c.circleId);
+    if (c.pillId !== null) _world.removePill(c.pillId);
+  }
+  _committed.length = 0;
+}
+
+// Quando uma malha tem visibility alternada (eye-toggle), esconde medições
+// ancoradas a ela (similar a measurement.js:104-110).
+function onMeshVisibilityChange(meshName, isVisible) {
+  for (const c of _committed) {
+    if (c.meshName !== meshName) continue;
+    _world.setMeasurementVisibility([c.circleId, c.pillId], isVisible);
+  }
+  // Centerline transiente + circle transiente
+  if (_P1 && _P1.meshName === meshName) {
+    const transientIds = [];
+    if (_centerlineId !== null) transientIds.push(_centerlineId);
+    if (_circleId !== null) transientIds.push(_circleId);
+    if (_pillId !== null) transientIds.push(_pillId);
+    if (transientIds.length) _world.setMeasurementVisibility(transientIds, isVisible);
+  }
+}
+
+// ===========================================================================
+// State transitions
+// ===========================================================================
+
+function _enter(next) {
+  _state = next;
+  switch (next) {
+    case STATE.IDLE:
+      _hint.clear();
+      _toolbar.hide();
+      break;
+    case STATE.PLACING_P1:
+      _hint.setText("Toque no vaso para colocar o primeiro ponto");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.CANDIDATE_P1:
+      _hint.setText("Arraste para ajustar, ou toque em outro ponto");
+      _toolbar.showConfirmRow("P1");
+      break;
+    case STATE.EXTRACTING_CL:
+      _hint.setText("Calculando linha central…");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.READY_SHORT:
+      _hint.setText("Toque na linha para medir, ou em um 2º ponto do mesmo vaso");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.PLACING_P2:
+      _hint.setText("Toque no segundo ponto do mesmo vaso");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.CANDIDATE_P2:
+      _hint.setText("Arraste para ajustar, ou toque em outro ponto");
+      _toolbar.showConfirmRow("P2");
+      break;
+    case STATE.EXTRACTING_CL_P1P2:
+      _hint.setText("Conectando os pontos pelo interior do vaso…");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.READY_LONG:
+      _hint.setText("Toque na linha para medir o calibre");
+      _toolbar.showCancelOnly();
+      break;
+    case STATE.CIRCLE_PLACED:
+      _hint.setText("Arraste o círculo (sobre a linha) ou confirme");
+      _toolbar.showResultRow();
+      break;
+    case STATE.COMMITTED:
+      _hint.setText("Toque na linha para nova medida, ou + Nova para outro vaso");
+      _toolbar.showCommittedRow();
+      break;
+  }
+}
+
+// Limpa tudo que é transiente (não-comprometido). Não toca _committed.
+function _clearTransient() {
+  _clearCandidate();
+  if (_P1) { _world.removeEndpoint(_P1.id); _P1 = null; }
+  if (_P2) { _world.removeEndpoint(_P2.id); _P2 = null; }
+  if (_centerlineId !== null) { _world.removeCenterline(_centerlineId); _centerlineId = null; }
+  if (_circleId !== null) { _world.removeDiameterCircle(_circleId); _circleId = null; }
+  if (_pillId !== null) { _world.removePill(_pillId); _pillId = null; }
+  _circleData = null;
+}
+
+function _clearCandidate() {
+  if (_candidate) {
+    _world.removeCandidate(_candidate.id);
+    _candidate = null;
+  }
+  if (_highlightedMeshName) {
+    _world.setMeshHighlight(_highlightedMeshName, false);
+    _highlightedMeshName = null;
+  }
+  _world.closeLoupe();
+  _loupe.setVisible(false);
+}
+
+// ===========================================================================
+// Confirm / + Nova
+// ===========================================================================
+
+function _onConfirm() {
+  if (_state === STATE.CANDIDATE_P1) {
+    if (!_candidate) return;
+    const epId = _world.addEndpoint(_candidate.point3D, "P1");
+    _P1 = {
+      id: epId,
+      point3D: _candidate.point3D.clone(),
+      meshName: _candidate.meshName,
+      faceIndex: _candidate.faceIndex,
+    };
+    _clearCandidate();
+    _enter(STATE.EXTRACTING_CL);
+    // Defer pra deixar o paint do hint acontecer antes do trabalho pesado
+    setTimeout(_runExtractionP1Only, 0);
+  } else if (_state === STATE.CANDIDATE_P2) {
+    if (!_candidate) return;
+    if (_candidate.meshName !== _P1.meshName) {
+      _hint.setText("P2 deve estar no mesmo vaso de P1. Tente novamente.");
+      return;
+    }
+    const epId = _world.addEndpoint(_candidate.point3D, "P2");
+    _P2 = {
+      id: epId,
+      point3D: _candidate.point3D.clone(),
+      meshName: _candidate.meshName,
+      faceIndex: _candidate.faceIndex,
+    };
+    _clearCandidate();
+    _enter(STATE.EXTRACTING_CL_P1P2);
+    setTimeout(_runExtractionP1P2, 0);
+  } else if (_state === STATE.CIRCLE_PLACED) {
+    if (!_circleData || _circleId === null) return;
+    // Pin: move o circle/pill transiente pra _committed e zera as refs.
+    _committed.push({
+      circleId: _circleId,
+      pillId:   _pillId,
+      meshName: _P1.meshName,
+      diameter: _circleData.diameter,
+      center: _circleData.center.clone(),
+      tangent: _circleData.tangent.clone(),
+    });
+    _circleId = null;
+    _pillId = null;
+    _circleData = null;
+    _enter(STATE.COMMITTED);
+  }
+}
+
+function _onNew() {
+  _clearTransient();
+  _enter(STATE.PLACING_P1);
+}
+
+// ===========================================================================
+// Centerline extraction (chama calibre-geom.js)
+// ===========================================================================
+
+function _runExtractionP1Only() {
+  const soup = _world.getMeshTriangleSoup(_P1.meshName);
+  if (!soup) {
+    _hint.setText("Erro: malha não carregada.");
+    return _enter(STATE.PLACING_P1);
+  }
+  const normal = _world.getMeshFaceNormalWorld(_P1.meshName, _P1.faceIndex);
+  if (!normal) {
+    _hint.setText("Erro: não foi possível ler a face do vaso.");
+    return _enter(STATE.PLACING_P1);
+  }
+
+  const result = geom.extractCenterline({
+    soup,
+    P1: _P1.point3D,
+    P1_normal: normal,
+    raycastInternal: (origin, dir) => _world.raycastInternal(_P1.meshName, origin, dir),
+  });
+
+  if (!result || !result.points || result.points.length < 1) {
+    _hint.setText("Não foi possível encontrar o lume do vaso. Tente outro ponto.");
+    _world.removeEndpoint(_P1.id);
+    _P1 = null;
+    return _enter(STATE.PLACING_P1);
+  }
+
+  _centerlineId = _world.addCenterline(result.points);
+
+  if (!result.isTubular) {
+    _hint.setText("Aviso: a estrutura não parece muito tubular. Resultado pode ser aproximado.");
+    setTimeout(() => { if (_state === STATE.READY_SHORT) _enter(STATE.READY_SHORT); }, 2500);
+  }
+  _enter(STATE.READY_SHORT);
+}
+
+function _runExtractionP1P2() {
+  if (_P1.meshName !== _P2.meshName) {
+    _hint.setText("P2 deve estar no MESMO vaso de P1.");
+    _world.removeEndpoint(_P2.id);
+    _P2 = null;
+    return _enter(STATE.READY_SHORT);
+  }
+  const soup = _world.getMeshTriangleSoup(_P1.meshName);
+  if (!soup) return _enter(STATE.READY_SHORT);
+
+  const normal1 = _world.getMeshFaceNormalWorld(_P1.meshName, _P1.faceIndex);
+  const normal2 = _world.getMeshFaceNormalWorld(_P2.meshName, _P2.faceIndex);
+
+  const result = geom.extractCenterline({
+    soup,
+    P1: _P1.point3D,
+    P1_normal: normal1,
+    P2: _P2.point3D,
+    P2_normal: normal2,
+    raycastInternal: (origin, dir) => _world.raycastInternal(_P1.meshName, origin, dir),
+  });
+
+  if (result && result.points && result.points.length >= 2) {
+    if (_centerlineId !== null) _world.removeCenterline(_centerlineId);
+    _centerlineId = _world.addCenterline(result.points, {
+      dashed: result.fallback === "straight",
+    });
+    if (result.fallback === "straight") {
+      _hint.setText("Não consegui traçar a curva exata — usando linha aproximada.");
+    }
+  }
+  _enter(STATE.READY_LONG);
+}
+
+// ===========================================================================
+// Pointer handling (tap vs drag)
+// ===========================================================================
+
+function _isInActiveMode() {
+  return _state !== STATE.IDLE && _state !== STATE.ASKING_VESSEL_TYPE;
+}
+
+function _onPointerDown(e) {
+  if (!_isInActiveMode()) return;
+  if (e.pointerType !== "mouse" && e.pointerType !== "touch" && e.pointerType !== "pen") return;
+
+  let onHandle = false;
+  if ((_state === STATE.CANDIDATE_P1 || _state === STATE.CANDIDATE_P2) && _candidate) {
+    const projected = _world.projectToScreen(_candidate.point3D);
+    const dx = e.clientX - projected.x;
+    const dy = e.clientY - projected.y;
+    onHandle = Math.hypot(dx, dy) < HANDLE_HITBOX_PX / 2;
+  }
+
+  let onCenterline = false;
+  if (_centerlineId !== null &&
+      (_state === STATE.READY_SHORT || _state === STATE.READY_LONG ||
+       _state === STATE.CIRCLE_PLACED || _state === STATE.COMMITTED)) {
+    const hit = _world.pickPointOnCenterline(_centerlineId, e.clientX, e.clientY, CENTERLINE_PICK_THRESHOLD_PX);
+    onCenterline = !!hit;
+  }
+
+  if (onHandle || onCenterline) _world.setControlsEnabled(false);
+
+  _touch = {
+    startX: e.clientX, startY: e.clientY, startT: performance.now(),
+    isOnHandle: onHandle,
+    isOnCenterline: onCenterline,
+    isDragging: false,
+  };
+}
+
+function _onPointerMove(e) {
+  if (!_touch) return;
+  const dx = e.clientX - _touch.startX;
+  const dy = e.clientY - _touch.startY;
+  if (Math.hypot(dx, dy) > TAP_THRESHOLD_PX) _touch.isDragging = true;
+
+  if (_touch.isOnHandle && _touch.isDragging && _candidate) {
+    const hit = _world.raycastFromScreen(e.clientX, e.clientY);
+    if (!hit) return;
+    // Em CANDIDATE_P2, restringe drag ao mesmo mesh do P1
+    if (_state === STATE.CANDIDATE_P2 && hit.meshName !== _P1.meshName) return;
+
+    _candidate.point3D.copy(hit.point3D);
+    _candidate.faceIndex = hit.faceIndex;
+    _world.moveCandidate(_candidate.id, hit.point3D);
+    if (_highlightedMeshName !== hit.meshName) {
+      if (_highlightedMeshName) _world.setMeshHighlight(_highlightedMeshName, false);
+      _world.setMeshHighlight(hit.meshName, true);
+      _highlightedMeshName = hit.meshName;
+      _candidate.meshName = hit.meshName;
+      _loupe.setLabel(hit.meshName);
+    }
+    _world.updateLoupe({ point3D: hit.point3D });
+    _loupe.setPosition(e.clientX, e.clientY);
+  } else if (_touch.isOnCenterline && _touch.isDragging) {
+    // Drag circle along centerline (READY ou CIRCLE_PLACED)
+    _dragCircleAtScreen(e.clientX, e.clientY);
+  }
+}
+
+function _onPointerUp(e) {
+  if (!_touch) return;
+  const wasOnHandle = _touch.isOnHandle;
+  const wasOnCenterline = _touch.isOnCenterline;
+  const wasDragging = _touch.isDragging;
+  const isTap =
+    Math.hypot(e.clientX - _touch.startX, e.clientY - _touch.startY) < TAP_THRESHOLD_PX &&
+    (performance.now() - _touch.startT) < TAP_THRESHOLD_MS;
+
+  if (isTap && !wasOnHandle && !wasOnCenterline) {
+    _handleTap(e.clientX, e.clientY);
+  } else if (isTap && wasOnCenterline) {
+    // Tap em cima da centerline: coloca/move o círculo
+    if (_state === STATE.READY_SHORT || _state === STATE.READY_LONG ||
+        _state === STATE.CIRCLE_PLACED || _state === STATE.COMMITTED) {
+      _placeCircleAtScreen(e.clientX, e.clientY);
+    }
+  } else if (wasDragging && wasOnCenterline && _state === STATE.READY_SHORT) {
+    // Se arrastou sobre a centerline ainda em READY, transição pra CIRCLE_PLACED
+    if (_circleId !== null) _enter(STATE.CIRCLE_PLACED);
+  } else if (wasDragging && wasOnCenterline && _state === STATE.READY_LONG) {
+    if (_circleId !== null) _enter(STATE.CIRCLE_PLACED);
+  } else if (wasDragging && wasOnCenterline && _state === STATE.COMMITTED) {
+    if (_circleId !== null) _enter(STATE.CIRCLE_PLACED);
+  }
+
+  if (wasOnHandle || wasOnCenterline) _world.setControlsEnabled(true);
+  _touch = null;
+}
+
+function _handleTap(screenX, screenY) {
+  if (_state === STATE.PLACING_P1 || _state === STATE.CANDIDATE_P1) {
+    _placeCandidateP1AtScreen(screenX, screenY);
+  } else if (_state === STATE.PLACING_P2 || _state === STATE.CANDIDATE_P2) {
+    _placeCandidateP2AtScreen(screenX, screenY);
+  } else if (_state === STATE.READY_SHORT || _state === STATE.READY_LONG) {
+    // Tap fora da centerline: se for no mesmo mesh do P1, vira PLACING_P2
+    const hit = _world.raycastFromScreen(screenX, screenY);
+    if (hit && hit.meshName === _P1.meshName && _state === STATE.READY_SHORT) {
+      _placeCandidateP2AtScreen(screenX, screenY);
+    } else if (hit && hit.meshName !== _P1.meshName) {
+      _hint.setText("Toque no MESMO vaso de P1 (ou na linha central)");
+    }
+    // Em READY_LONG, tap fora da centerline não faz nada
+  }
+}
+
+function _placeCandidateP1AtScreen(screenX, screenY) {
+  const hit = _world.raycastFromScreen(screenX, screenY);
+  if (!hit) return;
+  _clearCandidate();
+  const id = _world.addCandidate(hit.point3D);
+  _candidate = { id, point3D: hit.point3D.clone(), meshName: hit.meshName, faceIndex: hit.faceIndex };
+  _highlightedMeshName = hit.meshName;
+  _world.setMeshHighlight(hit.meshName, true);
+  _world.openLoupe({ point3D: hit.point3D });
+  _loupe.setLabel(hit.meshName);
+  _loupe.setPosition(screenX, screenY);
+  _loupe.setVisible(true);
+  if (_state !== STATE.CANDIDATE_P1) _enter(STATE.CANDIDATE_P1);
+}
+
+function _placeCandidateP2AtScreen(screenX, screenY) {
+  const hit = _world.raycastFromScreen(screenX, screenY);
+  if (!hit) return;
+  if (hit.meshName !== _P1.meshName) {
+    _hint.setText("P2 deve estar no MESMO vaso que P1.");
+    return;
+  }
+  _clearCandidate();
+  const id = _world.addCandidate(hit.point3D);
+  _candidate = { id, point3D: hit.point3D.clone(), meshName: hit.meshName, faceIndex: hit.faceIndex };
+  _highlightedMeshName = hit.meshName;
+  _world.setMeshHighlight(hit.meshName, true);
+  _world.openLoupe({ point3D: hit.point3D });
+  _loupe.setLabel(hit.meshName);
+  _loupe.setPosition(screenX, screenY);
+  _loupe.setVisible(true);
+  if (_state !== STATE.CANDIDATE_P2) _enter(STATE.CANDIDATE_P2);
+}
+
+function _placeCircleAtScreen(screenX, screenY) {
+  if (_centerlineId === null || !_P1) return;
+  const hit = _world.pickPointOnCenterline(_centerlineId, screenX, screenY, CENTERLINE_PICK_THRESHOLD_PX);
+  if (!hit) return;
+  const soup = _world.getMeshTriangleSoup(_P1.meshName);
+  if (!soup) return;
+
+  const result = geom.diameterAt(soup, hit.point3D, hit.tangent);
+  if (!result) {
+    _hint.setText("Não foi possível medir nesse ponto. Tente em outro lugar da linha.");
+    return;
+  }
+  _circleData = {
+    center:   hit.point3D.clone(),
+    tangent:  hit.tangent.clone(),
+    diameter: result.diameter,
+  };
+
+  if (_circleId === null) {
+    _circleId = _world.addDiameterCircle(_circleData.center, _circleData.tangent, _circleData.diameter / 2);
+    _pillId = _world.addPill(_circleData.center, _formatDiameter(result.diameter));
+  } else {
+    _world.updateDiameterCircle(_circleId, _circleData.center, _circleData.tangent, _circleData.diameter / 2);
+    _world.updatePill(_pillId, _circleData.center, _formatDiameter(result.diameter));
+  }
+  if (_state !== STATE.CIRCLE_PLACED) _enter(STATE.CIRCLE_PLACED);
+}
+
+function _dragCircleAtScreen(screenX, screenY) {
+  if (_centerlineId === null || !_P1) return;
+  const hit = _world.pickPointOnCenterline(_centerlineId, screenX, screenY, CENTERLINE_PICK_THRESHOLD_PX);
+  if (!hit) return;
+  const soup = _world.getMeshTriangleSoup(_P1.meshName);
+  if (!soup) return;
+  const result = geom.diameterAt(soup, hit.point3D, hit.tangent);
+  if (!result) return;
+  _circleData = _circleData || {
+    center: hit.point3D.clone(), tangent: hit.tangent.clone(), diameter: result.diameter,
+  };
+  _circleData.center.copy(hit.point3D);
+  _circleData.tangent.copy(hit.tangent);
+  _circleData.diameter = result.diameter;
+  if (_circleId === null) {
+    _circleId = _world.addDiameterCircle(hit.point3D, hit.tangent, result.diameter / 2);
+    _pillId = _world.addPill(hit.point3D, _formatDiameter(result.diameter));
+  } else {
+    _world.updateDiameterCircle(_circleId, hit.point3D, hit.tangent, result.diameter / 2);
+    _world.updatePill(_pillId, hit.point3D, _formatDiameter(result.diameter));
+  }
+}
+
+function _formatDiameter(d) {
+  return `${d.toFixed(1).replace(".", ",")} mm`;
+}

--- a/case-next/dom.js
+++ b/case-next/dom.js
@@ -226,8 +226,9 @@ export function mountMeasurementFAB({ onClick }) {
 
 const _MENU_ICON_RULER = `<path d="M3 12 L7 8 L21 8 L21 16 L7 16 Z"/><path d="M9 8 L9 12 M13 8 L13 12 M17 8 L17 12"/>`;
 const _MENU_ICON_CUBE = `<path d="M12 3 L21 8 L21 16 L12 21 L3 16 L3 8 Z"/><path d="M3 8 L12 13 L21 8 M12 13 L12 21"/>`;
+const _MENU_ICON_CALIBRE = `<circle cx="12" cy="12" r="6"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/>`;
 
-export function mountMeasurementMenu({ anchorEl, onPickLinear, onPickVolume }) {
+export function mountMeasurementMenu({ anchorEl, onPickLinear, onPickVolume, onPickCalibre }) {
   const wrapper = document.createElement("div");
   wrapper.className = "measure-menu";
   wrapper.dataset.open = "false";
@@ -240,6 +241,10 @@ export function mountMeasurementMenu({ anchorEl, onPickLinear, onPickVolume }) {
     <button type="button" class="measure-menu-item" data-tool="volume" data-testid="menu-volume">
       <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">${_MENU_ICON_CUBE}</svg></span>
       <span class="lbl"><span class="l1">Volume</span><span class="l2">3D · cm³</span></span>
+    </button>
+    <button type="button" class="measure-menu-item" data-tool="calibre" data-testid="menu-calibre">
+      <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">${_MENU_ICON_CALIBRE}</svg></span>
+      <span class="lbl"><span class="l1">Calibre</span><span class="l2">vaso · mm</span></span>
     </button>
   `;
   document.body.appendChild(wrapper);
@@ -280,6 +285,11 @@ export function mountMeasurementMenu({ anchorEl, onPickLinear, onPickVolume }) {
     wrapper.dataset.open = "false";
     _syncAnchorExpanded(anchorEl, false);
     onPickVolume();
+  });
+  wrapper.querySelector('[data-tool="calibre"]').addEventListener("click", () => {
+    wrapper.dataset.open = "false";
+    _syncAnchorExpanded(anchorEl, false);
+    if (onPickCalibre) onPickCalibre();
   });
 
   return {
@@ -488,6 +498,63 @@ export function mountLoupe() {
 // ===========================================================================
 // Sprint 3b.3 — Medição de volume (toolbar bottom-center: Sair / +Nova)
 // ===========================================================================
+
+// ===========================================================================
+// Sprint 3b.4 — Medição de calibre (vessel diameter)
+// ===========================================================================
+
+// Toolbar do modo Calibre. Variantes:
+//   cancelOnly()       — durante PLACING_P1, EXTRACTING_CL, READY_*
+//   confirmRow(label)  — durante CANDIDATE_P1 / CANDIDATE_P2
+//   resultRow()        — durante CIRCLE_PLACED (antes do pin)
+//   committedRow()     — após pin, permitindo + Nova ou sair
+export function mountCalibreToolbar({ onCancel, onConfirm, onNew, onExit }) {
+  const el = document.createElement("div");
+  el.className = "measure-toolbar";
+  el.dataset.testid = "calibre-toolbar";
+  el.hidden = true;
+  document.body.appendChild(el);
+
+  function makeBtn(label, klass, onClick, testid) {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.className = klass;
+    b.textContent = label;
+    b.dataset.testid = testid;
+    b.addEventListener("click", onClick);
+    return b;
+  }
+
+  return {
+    showCancelOnly() {
+      el.innerHTML = "";
+      el.appendChild(makeBtn("✕ Cancelar", "btn-secondary", onCancel, "btn-calibre-cancel"));
+      el.hidden = false;
+    },
+    showConfirmRow(label) {
+      el.innerHTML = "";
+      el.appendChild(makeBtn("✕ Cancelar", "btn-secondary", onCancel, "btn-calibre-cancel"));
+      el.appendChild(makeBtn(`✓ Confirmar ${label}`, "btn-primary", onConfirm, "btn-calibre-confirm"));
+      el.hidden = false;
+    },
+    showResultRow() {
+      el.innerHTML = "";
+      el.appendChild(makeBtn("✕ Cancelar", "btn-secondary", onCancel, "btn-calibre-cancel"));
+      el.appendChild(makeBtn("✓ Confirmar", "btn-primary", onConfirm, "btn-calibre-confirm"));
+      el.hidden = false;
+    },
+    showCommittedRow() {
+      el.innerHTML = "";
+      el.appendChild(makeBtn("✕ Sair", "btn-secondary", onExit, "btn-calibre-exit"));
+      el.appendChild(makeBtn("+ Nova", "btn-primary", onNew, "btn-calibre-new"));
+      el.hidden = false;
+    },
+    hide() {
+      el.innerHTML = "";
+      el.hidden = true;
+    },
+  };
+}
 
 export function mountVolumeToolbar({ onNew, onExit }) {
   const el = document.createElement("div");

--- a/case-next/main.js
+++ b/case-next/main.js
@@ -6,10 +6,12 @@ import * as loader from "./loader.js";
 import * as dom from "./dom.js";
 import * as measurement from "./measurement.js";
 import * as volume from "./volume.js";
+import * as calibre from "./calibre.js";
 import * as ar from "./ar.js";
 
 let measurementApi = null;
 let volumeApi = null;
+let calibreApi = null;
 let fab = null;
 
 async function bootstrap() {
@@ -69,6 +71,13 @@ async function bootstrap() {
     onExit: () => fab.setVisible(true),
   });
 
+  calibreApi = calibre.init({
+    world,
+    dom,
+    hint,
+    onExit: () => fab.setVisible(true),
+  });
+
   const menu = dom.mountMeasurementMenu({
     anchorEl: fab.getElement(),
     onPickLinear: () => {
@@ -78,6 +87,10 @@ async function bootstrap() {
     onPickVolume: () => {
       fab.setVisible(false);
       volumeApi.startVolume();
+    },
+    onPickCalibre: () => {
+      fab.setVisible(false);
+      calibreApi.startCalibre();
     },
   });
 
@@ -99,6 +112,7 @@ async function bootstrap() {
         dom.setSliderValue(name, 0);
       }
       measurementApi.onMeshVisibilityChange(name, visible);
+      if (calibreApi) calibreApi.onMeshVisibilityChange(name, visible);
     },
     onOpacityChange: (name, value) => {
       world.setOpacity(name, value);
@@ -318,4 +332,5 @@ if (window.__playwrightTest) {
   // Tests que dependem dele já esperam pelo painel renderizar (sinal que main.js terminou).
   Object.defineProperty(window, "__measurement", { get: () => measurementApi });
   Object.defineProperty(window, "__volume", { get: () => volumeApi });
+  Object.defineProperty(window, "__calibre", { get: () => calibreApi });
 }

--- a/case-next/world.js
+++ b/case-next/world.js
@@ -12,6 +12,7 @@ import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
 import { RenderPass } from "three/addons/postprocessing/RenderPass.js";
 import { OutlinePass } from "three/addons/postprocessing/OutlinePass.js";
 import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
+import { pickNearestSegment } from "./calibre-geom.js";
 
 let renderer, scene, camera, controls;
 let css2dRenderer;
@@ -32,7 +33,11 @@ const ndc = new THREE.Vector2();
 const measurementObjects = new Map();
 let nextMeasurementId = 1;
 
-const COLOR_ACCENT = 0xC8412C;
+const COLOR_ACCENT = 0xC8412C;       // usado só no OutlinePass (highlight da malha)
+// Amarelo de alto contraste pras geometrias de medição (linhas, pontos,
+// círculos). Vence vermelho (artéria), azul (veia) e verde (tumor) — não
+// se confunde com nenhuma cor anatômica padrão.
+const COLOR_MEASURE = 0xFFEB00;
 
 // Estado da lupa (segundo WebGLRenderer em canvas dedicado).
 let loupeRenderer = null;
@@ -134,9 +139,9 @@ function onResize() {
 
 function tick() {
   controls.update();
-  // Billboard + pulse: candidate sempre olha a câmera e tem leve respiração
-  // (1.0 → 1.08 → 1.0, ciclo ~1.5s) pra sinalizar afordância de drag.
-  const pulseScale = 1 + 0.08 * Math.sin(performance.now() * 0.004);
+  // Billboard + pulse: candidate sempre olha a câmera e tem respiração
+  // (0.88 → 1.12, ciclo ~1.5s) pra sinalizar afordância de drag.
+  const pulseScale = 1 + 0.12 * Math.sin(performance.now() * 0.004);
   for (const entry of measurementObjects.values()) {
     if (entry.type === "candidate") {
       entry.object3D.quaternion.copy(camera.quaternion);
@@ -306,7 +311,7 @@ export function onCameraChange(callback) {
 export function addEndpoint(point3D, label) {
   const id = nextMeasurementId++;
   const geom = new THREE.SphereGeometry(1.5, 24, 24);
-  const mat = new THREE.MeshBasicMaterial({ color: COLOR_ACCENT, depthTest: false });
+  const mat = new THREE.MeshBasicMaterial({ color: COLOR_MEASURE, depthTest: false });
   const mesh = new THREE.Mesh(geom, mat);
   mesh.position.copy(point3D);
   mesh.renderOrder = 999;
@@ -347,29 +352,39 @@ export function removeEndpoint(id) {
 
 export function addCandidate(point3D) {
   const id = nextMeasurementId++;
-  const radius = 2.5;
+  const radius = 3.5;
   const segments = 64;
 
-  // Anel tracejado externo
+  // Anel tracejado externo. Antes usava THREE.Line + LineDashedMaterial
+  // com `linewidth: 2` — mas no WebGL Line sempre renderiza 1px (limitação
+  // conhecida do GL). Line2 + LineMaterial honra linewidth em pixels via
+  // expansão geometry-shader-style.
   const ringPositions = [];
   for (let i = 0; i <= segments; i++) {
     const a = (i / segments) * Math.PI * 2;
     ringPositions.push(Math.cos(a) * radius, Math.sin(a) * radius, 0);
   }
-  const ringGeom = new THREE.BufferGeometry();
-  ringGeom.setAttribute("position", new THREE.Float32BufferAttribute(ringPositions, 3));
-  const ringMat = new THREE.LineDashedMaterial({
-    color: COLOR_ACCENT,
-    dashSize: 0.5,
-    gapSize: 0.35,
+  const ringGeom = new LineGeometry();
+  ringGeom.setPositions(ringPositions);
+  const ringMat = new LineMaterial({
+    color: COLOR_MEASURE,
+    linewidth: 4,
+    transparent: true,
     depthTest: false,
-    linewidth: 2,
+    depthWrite: false,
+    dashed: true,
+    dashSize: 6,
+    gapSize: 4,
+    dashScale: 1,
   });
-  const ring = new THREE.Line(ringGeom, ringMat);
+  const _r = renderer.domElement.getBoundingClientRect();
+  ringMat.resolution.set(_r.width || window.innerWidth, _r.height || window.innerHeight);
+  lineMaterials.add(ringMat);
+  const ring = new Line2(ringGeom, ringMat);
   ring.computeLineDistances();
 
   // Dot branco central (afordância de "centro do alvo / agarrável")
-  const dotGeom = new THREE.CircleGeometry(0.5, 16);
+  const dotGeom = new THREE.CircleGeometry(1.2, 24);
   const dotMat = new THREE.MeshBasicMaterial({ color: 0xffffff, depthTest: false });
   const dot = new THREE.Mesh(dotGeom, dotMat);
 
@@ -383,7 +398,7 @@ export function addCandidate(point3D) {
   dot.renderOrder = 1000;
 
   scene.add(group);
-  measurementObjects.set(id, { type: "candidate", object3D: group });
+  measurementObjects.set(id, { type: "candidate", object3D: group, ringMat });
   return id;
 }
 
@@ -397,7 +412,9 @@ export function removeCandidate(id) {
   const entry = measurementObjects.get(id);
   if (!entry || entry.type !== "candidate") return;
   scene.remove(entry.object3D);
-  // Candidato agora é um Group (anel + dot); descartar recursos dos filhos.
+  // Candidato é um Group (anel Line2 + dot Mesh). O ringMat (Line2) também
+  // precisa sair do lineMaterials set (atualizado no resize).
+  if (entry.ringMat) lineMaterials.delete(entry.ringMat);
   entry.object3D.traverse((c) => {
     if (c.geometry) c.geometry.dispose();
     if (c.material) c.material.dispose();
@@ -417,7 +434,7 @@ const LINE_GAP_SIZE = 4;
 
 function _makeLineMaterial(provisional) {
   const mat = new LineMaterial({
-    color: COLOR_ACCENT,
+    color: COLOR_MEASURE,
     linewidth: LINE_WIDTH_PX,
     transparent: true,
     depthTest: false,           // linha sempre na frente das estruturas
@@ -695,6 +712,302 @@ export function getMeshCentroid(name) {
 // monkey-patch externo não funcionaria.
 export function __testInjectVolumeCache(name, value) {
   _volumeCache.set(name, value);
+}
+
+// ===========================================================================
+// Sprint 3b.4 — Medição de calibre (vessel diameter)
+// ===========================================================================
+
+// Triangle soup cacheado por mesh: positions já transformadas pra world-space.
+// Espelha _volumeCache (acima): pague o custo da transformação UMA vez por mesh.
+const _triangleSoupCache = new Map();
+
+export function getMeshTriangleSoup(name) {
+  if (_triangleSoupCache.has(name)) return _triangleSoupCache.get(name);
+  const mesh = namedMeshes.get(name);
+  if (!mesh) return null;
+  mesh.updateMatrixWorld();
+  const geom = mesh.geometry;
+  const localPos = geom.attributes.position;
+  const indexAttr = geom.index;
+
+  const worldPositions = new Float32Array(localPos.count * 3);
+  const v = new THREE.Vector3();
+  for (let i = 0; i < localPos.count; i++) {
+    v.fromBufferAttribute(localPos, i).applyMatrix4(mesh.matrixWorld);
+    worldPositions[i * 3]     = v.x;
+    worldPositions[i * 3 + 1] = v.y;
+    worldPositions[i * 3 + 2] = v.z;
+  }
+
+  let worldIndices = null;
+  if (indexAttr) {
+    worldIndices = new Uint32Array(indexAttr.count);
+    for (let i = 0; i < indexAttr.count; i++) {
+      worldIndices[i] = indexAttr.getX(i);
+    }
+  }
+
+  const soup = { positions: worldPositions, indices: worldIndices };
+  _triangleSoupCache.set(name, soup);
+  return soup;
+}
+
+// Normal da face em world-space. Computa cross product de duas arestas do
+// triângulo já transformado. Sinal segue winding order do mesh — para malhas
+// orientadas pra fora, retorna o normal "pra fora" do lume.
+export function getMeshFaceNormalWorld(name, faceIndex) {
+  const soup = getMeshTriangleSoup(name);
+  if (!soup) return null;
+  const { positions, indices } = soup;
+  let i0, i1, i2;
+  if (indices) {
+    i0 = indices[faceIndex * 3] * 3;
+    i1 = indices[faceIndex * 3 + 1] * 3;
+    i2 = indices[faceIndex * 3 + 2] * 3;
+  } else {
+    i0 = faceIndex * 9;
+    i1 = faceIndex * 9 + 3;
+    i2 = faceIndex * 9 + 6;
+  }
+  const v0 = new THREE.Vector3(positions[i0],     positions[i0 + 1], positions[i0 + 2]);
+  const v1 = new THREE.Vector3(positions[i1],     positions[i1 + 1], positions[i1 + 2]);
+  const v2 = new THREE.Vector3(positions[i2],     positions[i2 + 1], positions[i2 + 2]);
+  const e1 = v1.sub(v0);
+  const e2 = v2.sub(v0);
+  return e1.cross(e2).normalize();
+}
+
+// Raycast contra um único mesh, usando o triangle soup world-space que já
+// temos cacheado. Bypass do THREE.Raycaster.intersectObject pra evitar
+// edge cases envolvendo matrixWorld stale ou BoundingSphere desatualizada
+// — vimos casos onde intersectObject retornava 0 hits mesmo com o ray
+// claramente cortando o mesh. Möller-Trumbore é O(N) por chamada mas
+// aceitável (50k tris × 6 cross-products ≈ 1-2 ms).
+const RAY_OFFSET_EPSILON = 0.001;
+const RAY_T_EPSILON = 1e-4;
+
+export function raycastInternal(meshName, origin, direction) {
+  const soup = getMeshTriangleSoup(meshName);
+  if (!soup) return null;
+  const dir = direction.clone().normalize();
+  const ox = origin.x + dir.x * RAY_OFFSET_EPSILON;
+  const oy = origin.y + dir.y * RAY_OFFSET_EPSILON;
+  const oz = origin.z + dir.z * RAY_OFFSET_EPSILON;
+
+  const { positions, indices } = soup;
+  const triCount = indices ? indices.length / 3 : positions.length / 9;
+  let bestT = Infinity;
+  let bestPx = 0, bestPy = 0, bestPz = 0;
+
+  const dx = dir.x, dy = dir.y, dz = dir.z;
+  // Möller-Trumbore inline com scratch numéricos
+  for (let t = 0; t < triCount; t++) {
+    let i0, i1, i2;
+    if (indices) {
+      i0 = indices[t * 3] * 3;
+      i1 = indices[t * 3 + 1] * 3;
+      i2 = indices[t * 3 + 2] * 3;
+    } else {
+      i0 = t * 9; i1 = t * 9 + 3; i2 = t * 9 + 6;
+    }
+    const v0x = positions[i0],     v0y = positions[i0 + 1], v0z = positions[i0 + 2];
+    const v1x = positions[i1],     v1y = positions[i1 + 1], v1z = positions[i1 + 2];
+    const v2x = positions[i2],     v2y = positions[i2 + 1], v2z = positions[i2 + 2];
+    const e1x = v1x - v0x, e1y = v1y - v0y, e1z = v1z - v0z;
+    const e2x = v2x - v0x, e2y = v2y - v0y, e2z = v2z - v0z;
+    // h = dir × e2
+    const hx = dy * e2z - dz * e2y;
+    const hy = dz * e2x - dx * e2z;
+    const hz = dx * e2y - dy * e2x;
+    const a = e1x * hx + e1y * hy + e1z * hz;
+    if (a > -1e-10 && a < 1e-10) continue; // paralelo
+    const f = 1 / a;
+    const sx = ox - v0x, sy = oy - v0y, sz = oz - v0z;
+    const u = f * (sx * hx + sy * hy + sz * hz);
+    if (u < 0 || u > 1) continue;
+    // q = s × e1
+    const qx = sy * e1z - sz * e1y;
+    const qy = sz * e1x - sx * e1z;
+    const qz = sx * e1y - sy * e1x;
+    const v = f * (dx * qx + dy * qy + dz * qz);
+    if (v < 0 || u + v > 1) continue;
+    const tt = f * (e2x * qx + e2y * qy + e2z * qz);
+    if (tt > RAY_T_EPSILON && tt < bestT) {
+      bestT = tt;
+      bestPx = ox + tt * dx;
+      bestPy = oy + tt * dy;
+      bestPz = oz + tt * dz;
+    }
+  }
+
+  if (!isFinite(bestT)) return null;
+  return new THREE.Vector3(bestPx, bestPy, bestPz);
+}
+
+// Constrói base ortonormal {u, w} perpendicular a `tangent` (que é o eixo
+// da centerline no ponto). Usado pra gerar os 64 vértices do círculo do
+// diâmetro no plano perpendicular.
+function _computeCirclePlaneBasis(tangent, u, w) {
+  const t = tangent.clone().normalize();
+  // Escolha ref que não seja paralelo a t pra evitar cross degenerado
+  const ref = (Math.abs(t.x) < 0.9) ? _refX : _refY;
+  u.crossVectors(t, ref).normalize();
+  w.crossVectors(t, u).normalize();
+}
+const _refX = new THREE.Vector3(1, 0, 0);
+const _refY = new THREE.Vector3(0, 1, 0);
+
+const CIRCLE_SEGMENTS = 64;
+const CIRCLE_LINEWIDTH_PX = 6;
+const CENTERLINE_LINEWIDTH_PX = 6;
+
+function _buildCirclePositions(center, tangent, radius) {
+  const u = new THREE.Vector3();
+  const w = new THREE.Vector3();
+  _computeCirclePlaneBasis(tangent, u, w);
+  const out = new Array((CIRCLE_SEGMENTS + 1) * 3);
+  for (let i = 0; i <= CIRCLE_SEGMENTS; i++) {
+    const a = (i / CIRCLE_SEGMENTS) * Math.PI * 2;
+    const cos = Math.cos(a), sin = Math.sin(a);
+    out[i * 3]     = center.x + radius * (cos * u.x + sin * w.x);
+    out[i * 3 + 1] = center.y + radius * (cos * u.y + sin * w.y);
+    out[i * 3 + 2] = center.z + radius * (cos * u.z + sin * w.z);
+  }
+  return out;
+}
+
+// --- Centerline (Line2 com depthTest:false; ID gerado, registrado em measurementObjects) ---
+
+export function addCenterline(points3D, { dashed = false } = {}) {
+  const id = nextMeasurementId++;
+  const positions = [];
+  for (const p of points3D) positions.push(p.x, p.y, p.z);
+  const geom = new LineGeometry();
+  geom.setPositions(positions);
+  // Match settings de addLine() acima: transparent + depthTest:false +
+  // depthWrite:false força a linha a aparecer mesmo dentro do vaso.
+  const mat = new LineMaterial({
+    color: COLOR_MEASURE,
+    linewidth: CENTERLINE_LINEWIDTH_PX,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+    dashed,
+    dashSize: dashed ? 4 : 1,
+    gapSize:  dashed ? 3 : 1,
+    dashScale: 1,
+  });
+  const _r = renderer.domElement.getBoundingClientRect();
+  mat.resolution.set(_r.width || window.innerWidth, _r.height || window.innerHeight);
+  lineMaterials.add(mat);
+
+  const line = new Line2(geom, mat);
+  line.computeLineDistances();
+  line.renderOrder = 999;
+  scene.add(line);
+
+  measurementObjects.set(id, {
+    type: "centerline",
+    object3D: line,
+    points: points3D.map(p => p.clone()),
+  });
+  return id;
+}
+
+export function updateCenterline(id, points3D) {
+  const entry = measurementObjects.get(id);
+  if (!entry || entry.type !== "centerline") return;
+  const positions = [];
+  for (const p of points3D) positions.push(p.x, p.y, p.z);
+  entry.object3D.geometry.setPositions(positions);
+  if (entry.object3D.material.dashed) entry.object3D.computeLineDistances();
+  entry.points = points3D.map(p => p.clone());
+}
+
+export function removeCenterline(id) {
+  const entry = measurementObjects.get(id);
+  if (!entry || entry.type !== "centerline") return;
+  scene.remove(entry.object3D);
+  entry.object3D.geometry.dispose();
+  lineMaterials.delete(entry.object3D.material);
+  entry.object3D.material.dispose();
+  measurementObjects.delete(id);
+}
+
+export function getCenterlinePoints(id) {
+  const entry = measurementObjects.get(id);
+  if (!entry || entry.type !== "centerline") return null;
+  return entry.points.map(p => p.clone());
+}
+
+// Hit-test screen-space pra ponto na polyline. Mais robusto que Raycaster
+// quando a centerline está parcialmente atrás de geometria translúcida.
+export function pickPointOnCenterline(centerlineId, x, y, threshold = 22) {
+  const entry = measurementObjects.get(centerlineId);
+  if (!entry || entry.type !== "centerline") return null;
+  const screenPts = entry.points.map(p => projectToScreen(p));
+  const hit = pickNearestSegment(screenPts, x, y, threshold);
+  if (!hit) return null;
+  const p1 = entry.points[hit.segmentIndex];
+  const p2 = entry.points[hit.segmentIndex + 1];
+  const point3D = new THREE.Vector3().lerpVectors(p1, p2, hit.t);
+  const tangent = new THREE.Vector3().subVectors(p2, p1).normalize();
+  return { point3D, segmentIndex: hit.segmentIndex, t: hit.t, tangent };
+}
+
+// --- Diameter circle (Line2 fechado, perpendicular à tangente) ---
+
+export function addDiameterCircle(center, tangent, radius) {
+  const id = nextMeasurementId++;
+  const positions = _buildCirclePositions(center, tangent, radius);
+  const geom = new LineGeometry();
+  geom.setPositions(positions);
+  const mat = new LineMaterial({
+    color: COLOR_MEASURE,
+    linewidth: CIRCLE_LINEWIDTH_PX,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+    dashed: false,
+  });
+  const _r = renderer.domElement.getBoundingClientRect();
+  mat.resolution.set(_r.width || window.innerWidth, _r.height || window.innerHeight);
+  lineMaterials.add(mat);
+
+  const line = new Line2(geom, mat);
+  line.computeLineDistances();
+  line.renderOrder = 999;
+  scene.add(line);
+
+  measurementObjects.set(id, {
+    type: "diameter-circle",
+    object3D: line,
+    center: center.clone(),
+    tangent: tangent.clone(),
+    radius,
+  });
+  return id;
+}
+
+export function updateDiameterCircle(id, center, tangent, radius) {
+  const entry = measurementObjects.get(id);
+  if (!entry || entry.type !== "diameter-circle") return;
+  const positions = _buildCirclePositions(center, tangent, radius);
+  entry.object3D.geometry.setPositions(positions);
+  entry.center.copy(center);
+  entry.tangent.copy(tangent);
+  entry.radius = radius;
+}
+
+export function removeDiameterCircle(id) {
+  const entry = measurementObjects.get(id);
+  if (!entry || entry.type !== "diameter-circle") return;
+  scene.remove(entry.object3D);
+  entry.object3D.geometry.dispose();
+  lineMaterials.delete(entry.object3D.material);
+  entry.object3D.material.dispose();
+  measurementObjects.delete(id);
 }
 
 // Updates the scene's clear-color background to the given hex string


### PR DESCRIPTION
## Summary

- Adds a third measurement mode **Calibre** alongside Linear and Volume in the case-next viewer. User taps a vessel surface (and optionally a second point on the same vessel), the system raycasts inward to find the opposite lumen wall, then runs local PCA + iterative cross-section marching to trace a centerline inside the vessel. Clicking any point on that centerline drops a circle perpendicular to the local tangent labeled with the equivalent-circle diameter (clinical standard: \`2·√(area/π)\`); the circle can be dragged along the centerline to reposition in real time.
- New modules: \`case-next/calibre-geom.js\` (pure math — triangle-plane intersection, polygon centroid/area, Jacobi PCA, marching, screen-space line picking; no DOM/globals) and \`case-next/calibre.js\` (state machine, mirrors \`measurement.js\`/\`volume.js\`). Extended \`world.js\` with cached world-space triangle soup, manual Möller-Trumbore raycast (replaces \`THREE.Raycaster.intersectObject\` which was returning empty due to matrixWorld/BoundingSphere edge cases), centerline + diameter-circle primitives, and \`pickPointOnCenterline\` for robust hit-testing through translucent meshes.
- Measurement geometry recolored to bright yellow \`#FFEB00\` so it stays visible over any anatomical color (red artery, blue vein, green tumor); the candidate "pulsing target" was switched from \`THREE.Line\` (which silently renders 1px in WebGL) to \`Line2\` so its linewidth is honored, and its inner dot bumped to 1.2mm for visibility on real anatomy.

## Test plan

- [ ] Open \`case-next/?id=<UID>\`, click **Medir → Calibre**, tap on a vessel → confirm P1 → verify the yellow centerline appears inside the vessel.
- [ ] Click any point on the centerline → diameter circle + pill (\`X,Y mm\`) appears perpendicular to the vessel.
- [ ] Drag the circle along the centerline → pill updates fluidly.
- [ ] Add a second measurement via **+ Nova** → both pills persist; clicking **✕ Sair** removes all calibre measurements.
- [ ] Regression: Linear (2 points) and Volume (tap mesh → cm³) still work; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)